### PR TITLE
fix: restrict scan to avoid tests import

### DIFF
--- a/push_messages/__init__.py
+++ b/push_messages/__init__.py
@@ -42,5 +42,5 @@ def main(global_config, **settings):
     config.add_route('delete_key', '/keys/{key}', request_method='DELETE')
     config.add_route('get_messages', '/messages/{key}', request_method='GET')
 
-    config.scan()
+    config.scan(".views")
     return config.make_wsgi_app()


### PR DESCRIPTION
I noticed when setting up the app on a new machine that the default scan hits all the files, causing imports in the tests.py file which shouldn't be needed to run the app in production.

@jrconlin r?
