### PR TITLE
feat: return 404 for no registered key, and refactor for redis only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,5 @@ HERE = $(shell pwd)
 
 all:	travis
 
-travis: $(HERE)/ddb
+travis:
 	pip install tox
-
-$(HERE)/ddb:
-	mkdir $@
-	curl -sSL http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz | tar xzvC $@

--- a/development.ini
+++ b/development.ini
@@ -21,7 +21,6 @@ pyramid_swagger.schema_file = push_api.yaml
 
 redis_host = localhost
 redis_db = 0
-dynamodb_key_table = push_messages_db
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.

--- a/production.ini
+++ b/production.ini
@@ -19,7 +19,6 @@ pyramid_swagger.schema_file = push_api.yaml
 
 redis_host = localhost
 redis_db = 0
-dynamodb_key_table = push_messages_db
 
 ###
 # wsgi server configuration

--- a/push_messages/db.py
+++ b/push_messages/db.py
@@ -1,5 +1,4 @@
 import boto3
-from boto3.dynamodb.conditions import Key
 
 
 def resolve_elasticache_node(cache_name):
@@ -13,70 +12,3 @@ def resolve_elasticache_node(cache_name):
         raise Exception("No cache cluster found of id: %s" % cache_name)
     cluster = result["CacheClusters"][0]
     return cluster["CacheNodes"][0]["Endpoint"]["Address"]
-
-
-def create_key_table(dynamodb, tablename):
-    table = dynamodb.create_table(
-        TableName=tablename,
-        KeySchema=[
-            {
-                'AttributeName': 'options',
-                'KeyType': 'HASH',
-            },
-            {
-                'AttributeName': 'pubkey',
-                'KeyType': 'RANGE'
-            }
-        ],
-        AttributeDefinitions=[
-            {
-                'AttributeName': 'options',
-                'AttributeType': 'S'
-            },
-            {
-                'AttributeName': 'pubkey',
-                'AttributeType': 'S'
-            }
-        ],
-        ProvisionedThroughput={
-            'ReadCapacityUnits': 5,
-            'WriteCapacityUnits': 5
-        }
-    )
-    table.meta.client.get_waiter('table_exists').wait(TableName=tablename)
-    return table
-
-
-def make_table_or_return(dynamodb, tablename):
-    table_names = [x.name for x in dynamodb.tables.all()]
-    if tablename in table_names:
-        return dynamodb.Table(tablename)
-    else:
-        return create_key_table(dynamodb, tablename)
-
-
-class KeyResource(object):
-    def __init__(self, tablename, autocreate=True, db_options=None):
-        db_opts = db_options or {}
-        dynamodb = boto3.resource("dynamodb", **db_opts)
-        self._tablename = tablename
-        if autocreate:
-            self._table = make_table_or_return(dynamodb, tablename)
-        else:
-            self._table = dynamodb.Table(tablename)
-
-    def all_keys(self):
-        response = self._table.query(
-            KeyConditionExpression=Key('options').eq('public_keys')
-        )
-        return response['Items']
-
-    def register_key(self, key):
-        self._table.put_item(
-            Item=dict(options='public_keys', pubkey=key)
-        )
-
-    def delete_key(self, key):
-        self._table.delete_item(
-            Key=dict(options='public_keys', pubkey=key)
-        )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,3 @@
 redis==2.10.5
 boto3==1.2.5
 waitress==0.8.10
-psutil==4.0.0


### PR DESCRIPTION
Get messages for an unregistered key now returns a 404, and a 204 if
there are no messages.

Refactored to use Redis only.

Closes #6 

@jrconlin r?
